### PR TITLE
Add archimede

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Awesome system information command-line fetch tools.
 
 ## Go
 
+- [archimede](https://github.com/gennaro-tedesco/archimede) - :bulb: Unobtrusive project information fetcher.
 - [gf](https://github.com/Smirnov-O/gf) - Simple system info written in GO.
 - [winfetch](https://github.com/M4cs/winfetch) - :computer: Neofetch/Screenfetch Alternative Written in Golang.
 


### PR DESCRIPTION
- [archimede](https://github.com/gennaro-tedesco/archimede) is a project directory information fetcher: minimalistic and fast
- unlike most other fetchers, it does not just retrieve screen system info, rather it retrieves information about the project you are working in (making it actually usable for working purposes)

![Screen-Recording-2021-06-02-at-2](https://user-images.githubusercontent.com/15387611/120616703-bacc0b80-c459-11eb-84bb-89d4d34920d6.gif)
