### PR TITLE
README: unarchive pridefetch, and add sfetch

### DIFF
--- a/ARCHIVE.md
+++ b/ARCHIVE.md
@@ -4,5 +4,4 @@
 
 - [gf](https://github.com/Smirnov-O/gf) - Simple system info written in GO. `Go`
 - [hsfetch](https://github.com/SleepyCatgirl/hsfetch) - Neofetch rewritten in haskell. `Haskell`
-- [pridefetch](https://github.com/charpointer/pridefetch) - Neofetch but gay. `Python`
 - [sfetch](https://github.com/sean0262/sfetch) - Sean's information fetch. A shell script for displaying system information on Linux/BSD distros. `Shell`

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Command-line fetch tools for system/other information. Operating system, kernel,
 - [NerdFetch](https://codeberg.org/thatonecalculator/NerdFetch) - A POSIX *nix fetch script using Nerdfonts. `Shell`
 - [vfetch](https://github.com/Lorago/vfetch) - A simple fetch tool for Linux written in Python. `Python`
 - [sf](https://github.com/mauro-balades/sf) - A small system information fetcher. `Shell`
+- [sfetch](https://github.com/Frolleks/sfetch) - A simple system fetch CLI tool written in Shell. `Shell`
 - [smfetch](https://github.com/agahemir/smfetch) - A fetch tool written in bash with less than 150 lines of code. `Shell`
 - [stupidfetch](https://github.com/000rosiu/stupidfetch) - Like neofetch, but without colors, without distro logos and installer. `Shell`
 - [nitch](https://github.com/ssleert/nitch) - A incredibly fast system fetch written in nim. `Nim`
@@ -93,6 +94,7 @@ Command-line fetch tools for system/other information. Operating system, kernel,
 - [inxi](https://github.com/smxi/inxi) - A faster, powerful, full featured CLI system information tool. `Perl`
 - [yarsi](https://github.com/LinuxNerdBTW/yarsi) - Yet another rust system info fetcher. `Rust`
 - [procfetch](https://github.com/TanmayPatil105/procfetch) -  A command-line system information utility. `C++`
+- [pridefetch](https://github.com/cartoon-raccoon/pridefetch) - Neofetch buy gay. `Python`
 
 ### MacOS Only
 - [mfetch-macos](https://github.com/TechWiz-3/mfetch-macos) - Minimalist fetch (forked and modified for mac OS). `Shell`


### PR DESCRIPTION
In [ARCHIVE.md](https://github.com/beucismis/awesome-fetch/blob/main/ARCHIVE.md)

I was able to find almost all of them in webarchive, but none of the actual content was cached.

- [gf](https://github.com/Smirnov-O/gf) - It's _likely_ that the owner of this repo has deleted the repository,
along with some other repository for some reason. 
- [hsfetch](https://github.com/SleepyCatgirl/hsfetch) - Repository either is private or deleted.
- [pridefetch](https://github.com/charpointer/pridefetch) - Repository seems to be deleted, but there was
a fork around and it worked.
- [sfetch](https://github.com/sean0262/sfetch) - Owner has deleted their account, and there are no forks
or cached content.

Commit [message](https://github.com/beucismis/awesome-fetch/commit/37dd8ef4b869159176b03451cab1f9767820994c).