### PR TITLE
Update turbofetch in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Command-line fetch tools for system/other information. Operating system, kernel,
 - [procfetch](https://github.com/TanmayPatil105/procfetch) -  A command-line system information utility. `C++`
 - [pridefetch](https://github.com/cartoon-raccoon/pridefetch) - Neofetch but gay. `Python`
 - [tinyfetch](https://github.com/beucismis/tinyfetch) - Python and system information command-line fetch tool. `Python`
-- [turbofetch](https://github.com/ajTronic/turbofetch) - A blazingly-fast, minimal fetch for Arch Linux (uses Nerd Fonts). `C`
+- [turbofetch](https://github.com/ajTronic/turbofetch) - A blazingly-fast, minimal fetch that uses Nerd Fonts. `C`
 - [xFetch](https://gitlab.com/XDRwastaken/xFetch) - A simple fetch written in Rust. `Rust`
 - [ufetch](https://github.com/tyroruyk/ufetch) - System fetch tool written in Rust. `Rust`
 

--- a/metadata.json
+++ b/metadata.json
@@ -436,7 +436,7 @@
     {
       "name": "turbofetch",
       "url": "https://github.com/ajTronic/turbofetch",
-      "description": "A blazingly-fast, minimal fetch for Arch Linux (uses Nerd Fonts).",
+      "description": "A blazingly-fast, minimal fetch (uses Nerd Fonts).",
       "language": "C"
     },
     {


### PR DESCRIPTION
TurboFetch has been updated and now works for multiple distros, so I removed 'for Arch Linux'.